### PR TITLE
Update CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(kansei_interfaces)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(kansei_interfaces)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
+rosidl_generate_interfaces(kansei_interfaces
   "msg/Axis.msg"
   "msg/Point3.msg"
   "msg/Status.msg"


### PR DESCRIPTION
This pull request updates the CMake configuration with the following changes:
- Removes the settings for `CMAKE_C_STANDARD` and `CMAKE_CXX_STANDARD` since setting C/C++ standards for an interface package is unnecessary, especially when the source files are generated and can't enforce specific rules.
- Removes the addition of warnings to compile options for the same reasons mentioned above.
- Explicitly specifies the target name as `kansei_interfaces` instead of relying on the project name.

This pull request closes #17.