### PR TITLE
Fix Source Branch for Push Event That Trigger CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 jobs:
   build-test:
     name: Build and Test


### PR DESCRIPTION
This pull request simply fixes the wrong name for source branch that could trigger push event of CI workflow.