### PR TITLE
Modify Workflow to Setup ROS 2 on Iron Irwini

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup workspace
         uses: ichiro-its/ros2-ws-action/setup@v1.0.0
         with:
-          distro: rolling
+          distro: iron
 
       - name: Build workspace
         uses: ichiro-its/ros2-ws-action/build@v1.0.0


### PR DESCRIPTION
This pull request simply modified CI workflow to setup ROS 2 on Iron Irwini instead on Rolling Ridley.